### PR TITLE
fix print statement (missing opening curly brace)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,7 +8,7 @@ IEventBus eventBus = EventBus();
 
 void main() {
   eventBus.on().listen((event) {
-    print('$DateTime.now()} Event: ${event}');
+    print('${DateTime.now()} Event: $event');
   });
 
   runApp(const MyApp());


### PR DESCRIPTION
Hey Andrew,

this is just a simple change to fix the print statement.

besides, I like your package. small and simple :)

two questions:
1. are you open for a PR to improve the example? (maybe even come up with a fresh one)
2. did you consider implementing IEventBus as a Singleton? ... I guess multiple event busses might still be interesting, maybe though with subclassing then? 🤔 

```Dart
class Singleton {
  static Singleton? _instance;

  Singleton._internal();

  factory Singleton() => _instance ??= Singleton._internal();
  
  void someMethod() {
    print("someMethod Called");
  }
}
```

Would be nice if you'd let me know what you think.

Greetings